### PR TITLE
[🐸 Frogbot] Update version of org.springframework:spring-webmvc to 6.1.14

### DIFF
--- a/examples/spring-mvc-webapp/pom.xml
+++ b/examples/spring-mvc-webapp/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.1.13.RELEASE</spring.version>
+        <spring.version>6.1.14</spring.version>
         <spring.security.version>5.1.13.RELEASE</spring.security.version>
         <jetty.version>9.4.34.v20201102</jetty.version>
     </properties>

--- a/modules/spring-commons/pom.xml
+++ b/modules/spring-commons/pom.xml
@@ -27,7 +27,7 @@
     <url>https://rest-assured.io/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.0.9.RELEASE</spring.version>
+        <spring.version>6.1.14</spring.version>
     </properties>
 
     <dependencies>

--- a/modules/spring-mock-mvc/pom.xml
+++ b/modules/spring-mock-mvc/pom.xml
@@ -28,7 +28,7 @@
     <url>https://rest-assured.io/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.1.13.RELEASE</spring.version>
+        <spring.version>6.1.14</spring.version>
         <spring.security.version>5.1.13.RELEASE</spring.security.version>
     </properties>
 

--- a/modules/spring-web-test-client-kotlin-extensions/pom.xml
+++ b/modules/spring-web-test-client-kotlin-extensions/pom.xml
@@ -28,7 +28,7 @@
     <url>https://rest-assured.io/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.1.13.RELEASE</spring.version>
+        <spring.version>6.1.14</spring.version>
     </properties>
 
     <dependencies>

--- a/modules/spring-web-test-client/pom.xml
+++ b/modules/spring-web-test-client/pom.xml
@@ -28,7 +28,7 @@
     <url>https://rest-assured.io/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>5.1.13.RELEASE</spring.version>
+        <spring.version>6.1.14</spring.version>
         <servlet-api.version>4.0.1</servlet-api.version>
         <spring.restdocs.version>2.0.2.RELEASE</spring.restdocs.version>
         <powermock-module-junit4.version>1.7.4</powermock-module-junit4.version>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![critical](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | CVE-2022-22965 | Applicable | org.springframework:spring-webmvc:5.1.13.RELEASE<br>io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT | org.springframework:spring-webmvc 5.1.13.RELEASE | [5.2.20.RELEASE]<br>[5.3.18] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | policy-sanity_maven_rest_assured_commit-1754920243 |
| **Watch Name:** | watch-sanity_maven_rest_assured_commit-1754920243 |
| **Jfrog Research Severity:** | <img src="https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/smallCritical.svg" alt=""/> Critical |
| **Contextual Analysis:** | Applicable |
| **Direct Dependencies:** | org.springframework:spring-webmvc:5.1.13.RELEASE, io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT |
| **Impacted Dependency:** | org.springframework:spring-webmvc:5.1.13.RELEASE |
| **Fixed Versions:** | [5.2.20.RELEASE], [5.3.18] |
| **CVSS V3:** | 9.8 |

A class loader vulnerability in Spring Web leads to remote code execution when binding a Java Bean.

### 🔬 JFrog Research Details

**Description:**
A vulnerability in Spring Web was leaked as a 0-day on Twitter, and later dubbed "SpringShell"

The vulnerability allows manipulation of the class loader, which leads to arbitrary file writing and other code execution impacts. This original exploit targeted webapps that ran on top of Apache Tomcat and used the class loader vulnerability to obtain arbitrary file writing privileges and drop a WebShell in a remotely-accessible location (ex. the webroot) in order to run arbitrary commands. Other exploitation vectors might exist which don't require the web app to run on top of Tomcat.

The issue is only exploitable on JDK 9 and later, when the Spring MVC app contains an endpoint that tries to bind request parameters to a non-primitive data type (Java Bean).
For example - this is a vulnerable endpoint -
```java
@RequestMapping({"", "/"})
    public String test(SomeJavaClass myclass) {
        ...
    }
```

As opposed to - 
```java
@RequestMapping({"", "/"})
    public String test(String mystring) {
        ...
    }
```

Note that although some advisories and tools regard the base `spring-beans` package to be vulnerable, the existence of this specific package is not enough for the remote exploitation of this vulnerability. This is due to the fact that vulnerable handlers must have the `@RequestMapping` annotation (or an equivalent annotation) and these annotations are available only in the `spring-web` package.

[More exploitability consideration in the blog post](https://jfrog.com/blog/springshell-zero-day-vulnerability-all-you-need-to-know/)

**Remediation:**
##### Development mitigations

Adding the following function to your `@RestController` class will mitigate the vulnerability -
```java
@InitBinder
public void initBinder(WebDataBinder binder) {
	String[] blackList = {"class.*","Class.*","*.class.*",".*Class.*"};
	binder.setDisallowedFields(blackList);
}
```



---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
